### PR TITLE
fix: enable enforcement for hidden files and directories

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ jobs:
   - job: dist_darwin
     displayName: "Dist Darwin binary"
     pool:
-      vmImage: macOS-10.13
+      vmImage: macOS-10.14
     steps:
       - template: ci/azure-install-rust.yml
       - script: cargo build --release

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn codeowners_enforcer(
     }
 
     // Always ignore .git directory
-    override_builder.add("!.git/*")?;
+    override_builder.add("!.git")?;
 
     let overrides = override_builder.build()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,11 +40,15 @@ fn codeowners_enforcer(
         override_builder.add(&format!("!{}", ignore_pattern))?;
     }
 
+    // Always ignore .git directory
+    override_builder.add("!.git/*")?;
+
     let overrides = override_builder.build()?;
 
     // Create iterator that walks the file system using the search+ignore patterns
     let walker = WalkBuilder::new(&cwd)
         .add_custom_ignore_filename(".codeownersignore")
+        .hidden(false)
         .parents(false)
         .git_global(false)
         .overrides(overrides)


### PR DESCRIPTION
Thank you for this awesome CLI tool, it really made enforcing codeowners quite easy for me!

The one issue I ran into is that hidden files/directories are not currently supported by the tool. So, for instance, if I want to enforce ownership of all GitHub actions in a repository (e.g. `.github/workflows`), it's currently not possible.

With this changeset, however, hidden files are now included.

For others interested in this change, I published the assets produced by the Azure pipeline build over on my fork: https://github.com/blimmer/codeowners-enforcer/releases/tag/v1.0.4 . I verified it was working on this test PR: https://github.com/blimmer/ensure-codeowners-demo/pull/7