### PR TITLE
docs: add reference to .codeownersignore file

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ codeowners-enforcer -i "path/**/*.py" -i "path/**/*.sh"
 one.txt
 ```
 
+Alternatively, you can create a `.codeownersignore` file in your repository.
+The file uses the same [syntax as a `.gitignore` file](https://git-scm.com/docs/gitignore#_pattern_format).
+
 If you want to only check certain files, pass `<patterns...>`:
 
 ```sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ jobs:
   - job: dist_darwin
     displayName: "Dist Darwin binary"
     pool:
-      vmImage: macOS-10.13
+      vmImage: macOS-10.14
     steps:
       - template: ci/azure-install-rust.yml
       - script: cargo build --release

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .short("i")
                 .multiple(true)
                 .value_name("PATTERN")
-                .help("Ignore some file patterns"),
+                .help("Ignore some file patterns. You can also use a .codeownersignore file to ignore many files."),
         )
         .arg(
             Arg::with_name("quiet")


### PR DESCRIPTION
Currently, you can create a `.codeownersignore` file to ignore many files. However, it's not documented in the usage or README, so it's only discoverable by looking at the source code (https://github.com/jamiebuilds/codeowners-enforcer/blob/b6bb45103c3579c989206b89154d6d161f1f5303/src/main.rs#L47).

This PR adds a reference in the `README` and in the cli help docs.