### PR TITLE
Fix postinstall script on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lib"
   ],
   "scripts": {
-    "postinstall": "./lib/install.js",
+    "postinstall": "node ./lib/install.js",
     "version": "./scripts/version.sh"
   },
   "dependencies": {


### PR DESCRIPTION
Windows users are having trouble installing this package, before this change they get the error "'.' is not recognized as an internal or external command,"

The problem seems to go away if we explicitly run install.js through node 